### PR TITLE
Fix country_code field

### DIFF
--- a/source/refs/content/payments/_cards.md.erb
+++ b/source/refs/content/payments/_cards.md.erb
@@ -32,7 +32,7 @@ can ask your customers to update their payment details.
 <span class="console-font">**address2**</span><br />*string*<br />Read-only | Cardholder secondary address line
 <span class="console-font">**city**</span><br />*string*<br />Read-only | Cardholder city
 <span class="console-font">**state**</span><br />*string*<br />Read-only | Cardholder state
-<span class="console-font">**country**</span><br />*string*<br />Read-only | Cardholder country
+<span class="console-font">**country_code**</span><br />*string*<br />Read-only | Cardholder country
 <span class="console-font">**zip**</span><br />*string*<br />Read-only | Cardholder zip
 <span class="console-font">**metadata**</span><br />[Metadata](#metadata)<br />*dictionary* | Context related to the card, key-value pair (string - string)
 <span class="console-font">**sandbox**</span><br />*boolean*<br />Read-only |

--- a/source/refs/content/payments/_customers.md.erb
+++ b/source/refs/content/payments/_customers.md.erb
@@ -22,7 +22,7 @@ additional data if needed.
 <span class="console-font">**city**</span><br />*string* | City of the customer
 <span class="console-font">**state**</span><br />*string* | State of the customer
 <span class="console-font">**zip**</span><br />*string* | ZIP code of the customer
-<span class="console-font">**country**</span><br />*string* | Customer's address country code (ex: `US`, `FR`)
+<span class="console-font">**country_code**</span><br />*string* | Customer's address country code (ex: `US`, `FR`)
 <span class="console-font">**metadata**</span><br />[Metadata](#metadata)<br />*dictionary* | Context related to the customer, key-value pair (string - string)
 <span class="console-font">**transactions_count**</span><br />*integer* | Number of transactions belonging to the customer
 <span class="console-font">**subscriptions_count**</span><br />*integer* | Number of subscriptions belonging to the customer

--- a/source/refs/content/payments/_events.md.erb
+++ b/source/refs/content/payments/_events.md.erb
@@ -54,7 +54,7 @@
             "bank_name": "",
             "brand": "",
             "city": null,
-            "country": "US",
+            "country_code": "US",
             "created_at": "2017-03-17T17:05:08.675622Z",
             "exp_month": 10,
             "exp_year": 2018,


### PR DESCRIPTION
For some objects of the reference, `country` was used instead of `country_code`.