### PR TITLE
Add further sandbox gateway flows

### DIFF
--- a/source/testing.md.erb
+++ b/source/testing.md.erb
@@ -98,7 +98,7 @@ the expiry date and CVC code of the cards will not be checked.
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0036</div> | The AVS check will fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0044</div> | The CVC and AVS checks will both fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0069</div> | The payment will be successful, but a chargeback will be initiated as soon as the payment makes it through
-<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0077</div> | The payment will be successful, but a refund will be declined
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0077</div> | The payment will be successful, but refunds will be declined
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0085</div> | The authorization will be successful, but an AVS Postal check will fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0093</div> | The authorization will be successful, but an AVS Street check will fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0200</div> | The payment will be successful, but a failed chargeback will be initiated as soon as the payment makes it through

--- a/source/testing.md.erb
+++ b/source/testing.md.erb
@@ -98,3 +98,8 @@ the expiry date and CVC code of the cards will not be checked.
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0036</div> | The AVS check will fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0044</div> | The CVC and AVS checks will both fail
 <div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0069</div> | The payment will be successful, but a chargeback will be initiated as soon as the payment makes it through
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0077</div> | The payment will be successful, but a refund will be declined
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0085</div> | The authorization will be successful, but an AVS Postal check will fail
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0093</div> | The authorization will be successful, but an AVS Street check will fail
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0200</div> | The payment will be successful, but a failed chargeback will be initiated as soon as the payment makes it through
+<div style="white-space: nowrap; color: #795da3;" class="console-font">4000 0000 0000 0309</div> | The payment will be successful, but a retrieval request will be initiated as soon as the payment makes it through


### PR DESCRIPTION
Add documentation for the following cards:

4000000000000077 - Card that makes refund fail
4000000000000085 - Card that fails AVS Postal only (Not Street)
4000000000000093 - Card that fails AVS Street only (Not postal)
4000000000000200 - Card that inserts a failed chargeback (Triggers upon capture)
4000000000000309 - Card that inserts a retrieval request (Triggers upon capture)