### PR TITLE
Bug: Fix preview tab on example sections failing to display

### DIFF
--- a/source/payments/alternative-payment-methods.md.erb
+++ b/source/payments/alternative-payment-methods.md.erb
@@ -32,12 +32,12 @@ web, or the customer is returned back to the app on mobile.
 <a href="#" data-language="css">CSS</a> 
 <a href="#" data-language="javascript">JS</a>
 </div>
-<div>
-<div class="highlight preview">
+<div class="highlight">
+<pre class="highlight preview">
 <script src="/javascripts/iframeSizer.min.js"></script>
 <iframe src="/payments/processoutjs-apms-example" frameborder="0" width="100%" class="rounded shadowed" id="processoutjs-example" style="min-height: 270px; margin-top: 0.9rem;"></iframe>
 <script>iFrameResize({heightCalculationMethod: "max"}, '#processoutjs-example')</script>
-</div>
+</pre>
 </div>
 
 ```html

--- a/source/payments/payments-and-sca.md.erb
+++ b/source/payments/payments-and-sca.md.erb
@@ -29,12 +29,12 @@ mostly enforced through 3DS2 or 3-D Secure version 2) in Europe.
 <a href="#" data-language="css">CSS</a> 
 <a href="#" data-language="javascript">JS</a>
 </div>
-<div>
-<div class="highlight preview">
+<div class="highlight">
+<pre class="highlight preview">
 <script src="/javascripts/iframeSizer.min.js"></script>
 <iframe src="/payments/processoutjs-example" frameborder="0" width="100%" class="rounded shadowed" id="processoutjs-example" style="min-height: 270px; margin-top: 0.9rem;"></iframe>
 <script>iFrameResize({heightCalculationMethod: "max"}, '#processoutjs-example')</script>
-</div>
+</pre>
 </div>
 
 ```html

--- a/source/payments/processoutjs-reference.md.erb
+++ b/source/payments/processoutjs-reference.md.erb
@@ -35,12 +35,12 @@ to be handled by ProcessOut.
 <a href="#" data-language="css">CSS</a> 
 <a href="#" data-language="javascript">JS</a>
 </div>
-<div>
-<div class="highlight preview">
+<div class="highlight">
+<pre class="highlight preview">
 <script src="/javascripts/iframeSizer.min.js"></script>
 <iframe src="/payments/processoutjs-example" frameborder="0" width="100%" class="rounded shadowed" id="processoutjs-example" style="min-height: 270px; margin-top: 0.9rem;"></iframe>
 <script>iFrameResize({heightCalculationMethod: "max"}, '#processoutjs-example')</script>
-</div>
+</pre>
 </div>
 
 ```html


### PR DESCRIPTION
### Description
Previously, the `Preview` tab on the code example sections were failing to display properly. This was happening because the script that conditionally hides or displays the relevant content expects these elements to match specific selectors:

https://github.com/processout/documentation/blob/660739436a20b053ed1d93305c5c396744630c2e/source/layouts/layout.erb#L263-L264

The markup for the previews was not properly matched by these selectors.

This PR fixes this issue by revising the markup on the previews to be consistent with the other tabs.